### PR TITLE
添加自定义检测ip个数功能 #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,19 +43,20 @@ go install github.com/peanut996/CloudflareWarpSpeedTest@latest
 要使用 CloudflareWarpSpeedTest，您可以运行以下命令行选项
 
 ```bash
-CloudflareWarpSpeedTest -n 200 -t 10 -tl 300 -q -tll 0 -tlr 0.2 -p 10 -f ip.txt -ip 1.1.1.1 -o result.csv -full
+CloudflareWarpSpeedTest -n 200 -t 10 -tl 300 -ip-number 1000 -tll 0 -tlr 0.2 -p 10 -f ip.txt -ip 1.1.1.1 -o result.csv -full
 ```
 
 以下是主要可用选项的解释：
 
-  + `-n`        200：指定延迟测试线程的数量。增加此值可以加快延迟测试过程，但不适合性能较低的设备，如路由器。默认值为 200，最大为 1000。
-  + `-t`        10：设置对每个 IP 地址执行延迟测试的次数。默认值为 10 次。
-  + `-q`        快速模式：快速扫描1000个地址结果。**默认打开**， 使用`-q=false` 关闭快速模式。
-  + `-ipv6`     ipv6模式：仅扫描ipv6地址。
-  + `-o`        result.csv：设置输出结果文件。默认文件为 "result.csv"。
-  + `-full`     此标志表示应测试指定范围内的所有端口。
-  + `-pri`      自定义wireguard的私钥。
-  + `-pub`      自定义wireguard的公钥。默认为WARP的公钥。
+  + `-n 200` 指定延迟测试线程的数量。增加此值可以加快延迟测试过程，但不适合性能较低的设备，如路由器。默认值为 200，最大为 1000。
+  + `-t 10` 设置对每个 IP 地址执行延迟测试的次数。默认值为 10 次。
+  + `-ip-number 1000` 扫描1000个地址结果。默认值为 10 次。使用`-all-ips`时无效。
+  + `-all-ips` 扫描全部IP。
+  + `-ipv6` ipv6模式，仅扫描ipv6地址。
+  + `-o result.csv` 设置输出结果文件。默认文件为 "result.csv"。
+  + `-full` 此标志表示应测试指定范围内的所有端口。
+  + `-pri` 自定义wireguard的私钥。
+  + `-pub` 自定义wireguard的公钥。默认为WARP的公钥。
   + `-reserved` 自定义Reserved字段。格式为`[0, 0, 0]`
 
 更多使用说明请使用`-h`。

--- a/README_EN.md
+++ b/README_EN.md
@@ -49,14 +49,15 @@ CloudflareWarpSpeedTest -n 200 -t 10 -tl 300 -q -tll 0 -tlr 0.2 -p 10 -f ip.txt 
 
 Here is an explanation of the main available options:
 
-  + `-n`        200: Specifies the number of latency test threads. Increasing this value can speed up the latency testing process, but it may not be suitable for lower-performance devices like routers. The default value is 200, with a maximum of 1000.
-  + `-t`        10: Sets the number of times latency tests are performed for each IP address. The default value is 10 times.
-  + `-q`        Quick mode: Quickly scan results for 1000 addresses. **Default is on**, use `-q=false` to turn off quick mode.
-  + `-ipv6`     IPv6 mode. Only scan ipv6 addresses. 
-  + `-o`        result.csv: Sets the output result file. The default file is \"result.csv\".
-  + `-full`     This flag indicates that all ports within the specified range should be tested.
-  + `-pri`      Custom Wireguard private key.
-  + `-pub`      Custom Wireguard public key. Default is the Warp public key.
+  + `-n 200` Specifies the number of latency test threads. Increasing this value can speed up the latency testing process, but it may not be suitable for lower-performance devices like routers. The default value is 200, with a maximum of 1000.
+  + `-t 10` Sets the number of times latency tests are performed for each IP address. The default value is 10 times.
+  + `-ip-number 1000` Scan only 1000 IPs. The default value is 1000。Unavaiable. No effect when `-all-ips` is used.
+  + `-all-ips` Scan all IPs.
+  + `-ipv6` IPv6 mode. Only scan ipv6 addresses. 
+  + `-o result.csv` Sets the output result file. The default file is \"result.csv\".
+  + `-full` This flag indicates that all ports within the specified range should be tested.
+  + `-pri` Custom Wireguard private key.
+  + `-pub` Custom Wireguard public key. Default is the Warp public key.
   + `-reserved` Custom Reserved. Format: `[0, 0, 0]`
   
 For more usage instructions, please use `-h`.

--- a/main.go
+++ b/main.go
@@ -25,8 +25,10 @@ Parameters:
         Latency test threads; the more threads, the faster the latency test, but do not set it too high on low-performance devices (such as routers); (default 200, maximum 1000)
     -t 10
         Number of latency tests; the number of times to test latency for a single IP; (default 10 times)
-    -q
-        Quick mode; test results for randomly scanning 1000 addresses; on by default, [-q=false] turns off quick mode
+    -ip-number
+        IP Number to detect.
+    -all-ips
+        Detect all IPs.
     -ipv6
         IPv6 support. Only effect when not provide extra ip cidr.
     -tl 300
@@ -67,7 +69,8 @@ Parameters:
 	flag.Float64Var(&maxLossRate, "tlr", 1, "Packet loss rate upper limit")
 
 	flag.BoolVar(&task.ScanAllPort, "full", false, "Scan all ports")
-	flag.BoolVar(&task.QuickMode, "q", true, "Quick mode, test results for randomly scanning 1000 IPs")
+	flag.IntVar(&task.IPNumberToDetect, "ip-number", 1000, "IP Number to detect. Default is 1000.")
+	flag.BoolVar(&task.AllIPsMode, "all-ips", false, "Detect all IPs. Default is false.")
 	flag.BoolVar(&task.IPv6Mode, "ipv6", false, "IPv6 support. Only effect when not provide extra ip cidr.")
 	flag.IntVar(&utils.PrintNum, "p", 10, "Number of results to display")
 	flag.StringVar(&task.IPFile, "f", "", "IP segment data file")

--- a/main.go
+++ b/main.go
@@ -26,9 +26,9 @@ Parameters:
     -t 10
         Number of latency tests; the number of times to test latency for a single IP; (default 10 times)
     -ip-number
-        IP Number to detect.
+        IP Number to scan.
     -all-ips
-        Detect all IPs.
+        Scan all IPs.
     -ipv6
         IPv6 support. Only effect when not provide extra ip cidr.
     -tl 300
@@ -69,8 +69,8 @@ Parameters:
 	flag.Float64Var(&maxLossRate, "tlr", 1, "Packet loss rate upper limit")
 
 	flag.BoolVar(&task.ScanAllPort, "full", false, "Scan all ports")
-	flag.IntVar(&task.IPNumberToDetect, "ip-number", 1000, "IP Number to detect. Default is 1000.")
-	flag.BoolVar(&task.AllIPsMode, "all-ips", false, "Detect all IPs. Default is false.")
+	flag.IntVar(&task.IPNumberToScan, "ip-number", 1000, "IP Number to scan. Default is 1000.")
+	flag.BoolVar(&task.AllIPsMode, "all-ips", false, "Scan all IPs. Default is false.")
 	flag.BoolVar(&task.IPv6Mode, "ipv6", false, "IPv6 support. Only effect when not provide extra ip cidr.")
 	flag.IntVar(&utils.PrintNum, "p", 10, "Number of results to display")
 	flag.StringVar(&task.IPFile, "f", "", "IP segment data file")

--- a/task/warping.go
+++ b/task/warping.go
@@ -41,7 +41,7 @@ var (
 
 	AllIPsMode = false
 
-  	IPNumberToDetect = 1000
+  	IPNumberToScan = 1000
 
 	IPv6Mode = false
 
@@ -181,8 +181,8 @@ func (w *Warping) appendIPData(data *utils.PingData) {
 func loadWarpIPRanges() (ipAddrs []*UDPAddr) {
 	ips := loadIPRanges()
 	addrs := generateIPAddrs(ips)
-	if !AllIPsMode && len(addrs) > IPNumberToDetect {
-		return addrs[:IPNumberToDetect]
+	if !AllIPsMode && len(addrs) > IPNumberToScan {
+		return addrs[:IPNumberToScan]
 	}
 	return addrs
 }

--- a/task/warping.go
+++ b/task/warping.go
@@ -31,7 +31,6 @@ const (
 	defaultPingTimes            = 10
 	udpConnectTimeout           = time.Millisecond * 1000
 	wireguardHandshakeRespBytes = 92
-	quickModeMaxIpNum           = 1000
 	warpPublicKey               = "bmXOC+F1FxEMF9dyiK2H5/1SUtzH0JuVo51h2wPfgyo="
 )
 
@@ -40,7 +39,9 @@ var (
 
 	PublicKey string
 
-	QuickMode = false
+	AllIPsMode = false
+
+  	IPNumberToDetect = 1000
 
 	IPv6Mode = false
 
@@ -180,8 +181,8 @@ func (w *Warping) appendIPData(data *utils.PingData) {
 func loadWarpIPRanges() (ipAddrs []*UDPAddr) {
 	ips := loadIPRanges()
 	addrs := generateIPAddrs(ips)
-	if QuickMode && len(addrs) > quickModeMaxIpNum {
-		return addrs[:quickModeMaxIpNum]
+	if !AllIPsMode && len(addrs) > IPNumberToDetect {
+		return addrs[:IPNumberToDetect]
 	}
 	return addrs
 }


### PR DESCRIPTION
来源于 #16 。对代码、README进行了一些修改。

- 添加 `-all-ips` 参数，用于扫描所有IP。
- 添加 `-ip-number`，用于设置将要扫描IP数量。
- 删去 `-q`