### PR TITLE
feat: update `math/rand` to `math/rand/v2` and support go 1.22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.22'
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,5 +42,5 @@ jobs:
         goarch: ${{ matrix.goarch }}
         project_path: "."
         binary_name: "CloudflareWarpSpeedTest"
-        goversion: "1.20"
+        goversion: "1.22"
         ldflags: "${{ env.LD_FLAGS }}"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ paru -S cloudflarewarpspeedtest-bin
 ```
 
 #### Go Install
-use go tool to install(go version <= 1.20)
+use go tool to install(go version recommend 1.22)
 
 ```bash
 go install github.com/peanut996/CloudflareWarpSpeedTest@latest

--- a/README_CN.md
+++ b/README_CN.md
@@ -35,7 +35,7 @@ paru -S cloudflarewarpspeedtest-bin
 ```
 
 #### Go Install
-使用go官方工具链安装(go版本<=1.20)
+使用go官方工具链安装(go版本推荐1.22)
 
 ```bash
 go install github.com/peanut996/CloudflareWarpSpeedTest@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/peanut996/CloudflareWarpSpeedTest
 
-go 1.20
+go 1.22
 
 require (
 	github.com/cheggaaa/pb/v3 v3.1.4

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.20
 
 require (
 	github.com/cheggaaa/pb/v3 v3.1.4
-	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
-	golang.org/x/text v0.14.0
 	golang.org/x/crypto v0.13.0
+	golang.org/x/text v0.14.0
+	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.20
 require (
 	github.com/cheggaaa/pb/v3 v3.1.4
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
+	golang.org/x/text v0.14.0
+	golang.org/x/crypto v0.13.0
 )
-
-require golang.org/x/text v0.14.0
 
 require (
 	github.com/BurntSushi/toml v1.4.0
@@ -19,7 +19,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/nicksnyder/go-i18n/v2 v2.4.0
 	github.com/rivo/uniseg v0.2.0 // indirect
-	golang.org/x/crypto v0.13.0
 	golang.org/x/net v0.15.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,5 @@ golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2/go.mod h1:deeaetjYA+D
 golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 h1:/jFs0duh4rdb8uIfPMv78iAJGcPKDeqAFnaLBropIC4=
 golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173/go.mod h1:tkCQ4FQXmpAgYVh++1cq16/dH4QJtmvpRv19DWGAHSA=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259 h1:TbRPT0HtzFP3Cno1zZo7yPzEEnfu8EjLfl6IU9VfqkQ=
 gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259/go.mod h1:AVgIgHMwK63XvmAzWG9vLQ41YnVHN0du0tEC46fI7yY=

--- a/go.sum
+++ b/go.sum
@@ -36,5 +36,6 @@ golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2/go.mod h1:deeaetjYA+D
 golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 h1:/jFs0duh4rdb8uIfPMv78iAJGcPKDeqAFnaLBropIC4=
 golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173/go.mod h1:tkCQ4FQXmpAgYVh++1cq16/dH4QJtmvpRv19DWGAHSA=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259 h1:TbRPT0HtzFP3Cno1zZo7yPzEEnfu8EjLfl6IU9VfqkQ=
 gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259/go.mod h1:AVgIgHMwK63XvmAzWG9vLQ41YnVHN0du0tEC46fI7yY=

--- a/main.go
+++ b/main.go
@@ -58,7 +58,6 @@ func init() {
 }
 
 func main() {
-	task.InitRandSeed()
 	task.InitHandshakePacket()
 
 	fmt.Printf("CloudflareWarpSpeedTest\n\n")

--- a/task/ip.go
+++ b/task/ip.go
@@ -3,12 +3,11 @@ package task
 import (
 	"bufio"
 	"log"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	i18n "github.com/peanut996/CloudflareWarpSpeedTest/locale"
 )
@@ -20,11 +19,6 @@ var (
 	IPFile string
 )
 
-func InitRandSeed() *rand.Rand {
-	source := rand.NewSource(time.Now().UnixNano())
-	return rand.New(source)
-}
-
 func isIPv4(ip string) bool {
 	return strings.Contains(ip, ".")
 }
@@ -33,7 +27,7 @@ func randIPEndWith(num byte) byte {
 	if num == 0 { // 对于 /32 这种单独的 IP
 		return byte(0)
 	}
-	return byte(InitRandSeed().Intn(int(num)))
+	return byte(rand.IntN(int(num)))
 }
 
 type IPRanges struct {

--- a/task/ip.go
+++ b/task/ip.go
@@ -20,8 +20,9 @@ var (
 	IPFile string
 )
 
-func InitRandSeed() {
-	rand.Seed(time.Now().UnixNano())
+func InitRandSeed() *rand.Rand {
+	source := rand.NewSource(time.Now().UnixNano())
+	return rand.New(source)
 }
 
 func isIPv4(ip string) bool {
@@ -32,7 +33,7 @@ func randIPEndWith(num byte) byte {
 	if num == 0 { // 对于 /32 这种单独的 IP
 		return byte(0)
 	}
-	return byte(rand.Intn(int(num)))
+	return byte(InitRandSeed().Intn(int(num)))
 }
 
 type IPRanges struct {


### PR DESCRIPTION
1. go 1.22 添加了 std lib `math/rand/v2`[移除了Source.Seed、Rand.Seed 和顶层 Seed。（意味着像 Int 这样的顶层函数将总是随机播种）],同时解决了一些性能问题
2. 此更改会导致支持且仅支持`go>=1.22`
3. 以本地测试程序可正常运行