### PR TITLE
fix pipeline: add GOMIPS flag for mips devices

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
+        gomips: ${{ matrix.gomips }}
         project_path: "."
         binary_name: "CloudflareWarpSpeedTest"
         goversion: "1.22"


### PR DESCRIPTION
忘记给gomips flag加上了。

还有个bug要修一下：  
打印help信息时版本号和后文没有换行，（第2行）
```
CloudflareWarpSpeedTest 
v1.5.3测试 Cloudflare Warp 所有 IP 的延迟和速度，获取最快 IP (IPv4+IPv6)！
使用 -h, --help 以打印帮助信息.

选项:  -all
    	此标志表示应测试所有的IP和端口的组合
```