### PR TITLE
Improve release workflow: Add armv7 support and fix MIPS build issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Build
       run: |
         mkdir -p build-${{ matrix.goarch }}
-        GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} go build -v -o build-${{ matrix.goarch }}/CloudflareWarpSpeedTest ./...
+        GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} go build -v -o build-${{ matrix.goarch }}/ ./...
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,3 @@
-# This workflow will build a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
 name: Go Build
 
 on:
@@ -13,6 +10,12 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goarch: [amd64, arm64, arm]
+        include:
+          - goarch: arm
+            goarm: 7
     steps:
     - uses: actions/checkout@v3
 
@@ -22,4 +25,10 @@ jobs:
         go-version: '1.22'
 
     - name: Build
-      run: go build -v ./...
+      run: GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} go build -v -o CloudflareWarpSpeedTest-${{ matrix.goarch }} ./...
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: CloudflareWarpSpeedTest-${{ matrix.goarch }}
+        path: CloudflareWarpSpeedTest-${{ matrix.goarch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,10 @@ jobs:
           - goarch: arm
             goarm: 7
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: '1.22'
 
@@ -30,7 +30,7 @@ jobs:
         GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} go build -v -o build-${{ matrix.goarch }}/ ./...
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: CloudflareWarpSpeedTest-${{ matrix.goarch }}
         path: build-${{ matrix.goarch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,12 @@ jobs:
         go-version: '1.22'
 
     - name: Build
-      run: GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} go build -v -o CloudflareWarpSpeedTest-${{ matrix.goarch }} ./...
+      run: |
+        mkdir -p build-${{ matrix.goarch }}
+        GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} go build -v -o build-${{ matrix.goarch }}/CloudflareWarpSpeedTest ./...
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
         name: CloudflareWarpSpeedTest-${{ matrix.goarch }}
-        path: CloudflareWarpSpeedTest-${{ matrix.goarch }}
+        path: build-${{ matrix.goarch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,6 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
 name: Go Build
 
 on:
@@ -10,12 +13,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        goarch: [amd64, arm64, arm]
-        include:
-          - goarch: arm
-            goarm: 7
     steps:
     - uses: actions/checkout@v4
 
@@ -25,12 +22,4 @@ jobs:
         go-version: '1.22'
 
     - name: Build
-      run: |
-        mkdir -p build-${{ matrix.goarch }}
-        GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} go build -v -o build-${{ matrix.goarch }}/ ./...
-
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: CloudflareWarpSpeedTest-${{ matrix.goarch }}
-        path: build-${{ matrix.goarch }}
+      run: go build -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
         exclude:
           - goos: darwin
             goarch: arm 
+          - goos: darwin
+            goarch: 386
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux, windows, darwin]
-        goarch: [amd64, arm64, arm]
-        include:
-          - goos: linux
-            goarch: arm
-            goarm: 7
-        exclude:
-          - goos: darwin
-            goarch: arm
+        goos: [linux]
+        goarch: [arm]
+        goarm: [7]
     steps:
       - uses: actions/checkout@v4
 
@@ -44,15 +38,9 @@ jobs:
 
       - name: Release
         uses: softprops/action-gh-release@v1
-        if: ${{ matrix.goos == 'linux' && matrix.goarch == 'amd64' }}
+        if: ${{ matrix.goos == 'linux' && matrix.goarch == 'arm' && matrix.goarm == '7' }}
         with:
           files: |
-            ${{ github.workspace }}/build-linux-amd64/CloudflareWarpSpeedTest
-            ${{ github.workspace }}/build-linux-arm64/CloudflareWarpSpeedTest
             ${{ github.workspace }}/build-linux-arm/CloudflareWarpSpeedTest
-            ${{ github.workspace }}/build-windows-amd64/CloudflareWarpSpeedTest
-            ${{ github.workspace }}/build-windows-arm64/CloudflareWarpSpeedTest
-            ${{ github.workspace }}/build-darwin-amd64/CloudflareWarpSpeedTest
-            ${{ github.workspace }}/build-darwin-arm64/CloudflareWarpSpeedTest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         fi
         echo "LD_FLAGS=$LD_FLAGS" >> ${GITHUB_ENV}
 
-    - uses: wangyoucao577/go-release-action@v1.51
+    - uses: wangyoucao577/go-release-action@v1.51 
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,6 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
 name: Go-Releaser
 
 on:
@@ -14,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux, windows]
+        goos: [linux, windows]  # 移除 darwin
         goarch: [amd64, arm64, arm]
         include:
           - goos: linux
@@ -33,17 +36,25 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.22'
+    - name: Set APP_VERSION env
+      run: echo APP_VERSION=$(basename ${GITHUB_REF}) >> ${GITHUB_ENV}
 
-    - name: Build
-      run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} GOMIPS=${{ matrix.gomips }} go build -ldflags "-X main.Version=${{ github.ref_name }}" -o CloudflareWarpSpeedTest-${{ matrix.goos }}-${{ matrix.goarch }}
+    - name: Set ldflags as environment variable
+      run: |
+        if [ ${{ matrix.goos }} == 'linux' ]&&[ ${{ matrix.goarch }} == 'amd64' ]; then
+          LD_FLAGS="-X main.Version=${{ env.APP_VERSION }} -linkmode 'external' -extldflags '-static'"
+        else
+          LD_FLAGS="-X main.Version=${{ env.APP_VERSION }}"
+        fi
+        echo "LD_FLAGS=$LD_FLAGS" >> ${GITHUB_ENV}
 
-    - name: Release
-      uses: softprops/action-gh-release@v1
+    - uses: wangyoucao577/go-release-action@v1
       with:
-        files: CloudflareWarpSpeedTest-${{ matrix.goos }}-${{ matrix.goarch }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        gomips: ${{ matrix.gomips }}
+        project_path: "."
+        binary_name: "CloudflareWarpSpeedTest"
+        goversion: "1.22"
+        ldflags: "${{ env.LD_FLAGS }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux, windows, darwin]
-        goarch: [amd64, arm64, arm]  # 添加 arm
+        goos: [linux, windows]  # 移除 darwin
+        goarch: [amd64, arm64, arm]
         include:
           - goos: linux
             goarch: mips
@@ -30,7 +30,7 @@ jobs:
             goarch: mips64
           - goos: linux
             goarch: mips64le
-          - goos: linux  # 添加 armv7 配置
+          - goos: linux
             goarch: arm
             goarm: 7
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           - goos: darwin
             goarch: arm 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set APP_VERSION env
       run: echo APP_VERSION=$(basename ${GITHUB_REF}) >> ${GITHUB_ENV}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,46 +1,58 @@
-name: Go Release
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go-Releaser
 
 on:
   release:
     types: [created]
 
 permissions:
-  contents: write
-  packages: write
+    contents: write
+    packages: write
 
 jobs:
-  release:
+  releases-matrix:
+    name: Release Go Binary
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux]
-        goarch: [arm]
-        goarm: [7]
+        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, darwin/amd64, darwin/arm64
+        goos: [linux, windows, darwin]
+        goarch: [amd64, arm64]
+        include:
+          - goos: linux
+            goarch: mips
+            gomips: softfloat
+          - goos: linux
+            goarch: mipsle
+            gomips: softfloat
+          - goos: linux
+            goarch: mips64
+          - goos: linux
+            goarch: mips64le
     steps:
-      - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.22'
+    - name: Set APP_VERSION env
+      run: echo APP_VERSION=$(basename ${GITHUB_REF}) >> ${GITHUB_ENV}
 
-      - name: Build
-        run: |
-          cd ${{ github.workspace }} 
-          mkdir -p build-${{ matrix.goos }}-${{ matrix.goarch }}
-          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} go build -v -o build-${{ matrix.goos }}-${{ matrix.goarch }}/CloudflareWarpSpeedTest ./...
+    - name: Set ldflags as environment variable
+      run: |
+        if [ ${{ matrix.goos }} == 'linux' ]&&[ ${{ matrix.goarch }} == 'amd64' ]; then
+          LD_FLAGS="-X main.Version=${{ env.APP_VERSION }} -linkmode 'external' -extldflags '-static'"
+        else
+          LD_FLAGS="-X main.Version=${{ env.APP_VERSION }}"
+        fi
+        echo "LD_FLAGS=$LD_FLAGS" >> ${GITHUB_ENV}
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: CloudflareWarpSpeedTest-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: build-${{ matrix.goos }}-${{ matrix.goarch }}
-
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: ${{ matrix.goos == 'linux' && matrix.goarch == 'arm' && matrix.goarm == '7' }}
-        with:
-          files: |
-            ${{ github.workspace }}/build-linux-arm/CloudflareWarpSpeedTest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: wangyoucao577/go-release-action@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        gomips: ${{ matrix.gomips }}
+        project_path: "."
+        binary_name: "CloudflareWarpSpeedTest"
+        goversion: "1.22"
+        ldflags: "${{ env.LD_FLAGS }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         fi
         echo "LD_FLAGS=$LD_FLAGS" >> ${GITHUB_ENV}
 
-    - uses: wangyoucao577/go-release-action@v1.51 
+    - uses: pdahd/go-release-action@v0.1-test-assets
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           cd ${{ github.workspace }} 
           mkdir -p build-${{ matrix.goos }}-${{ matrix.goarch }}
-          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} go build -v -o build-${{ matrix.goos }}-${{ matrix.goarch }} ./...
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} go build -v -o build-${{ matrix.goos }}-${{ matrix.goarch }}/CloudflareWarpSpeedTest ./...
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,3 @@
-# This workflow will build a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
 name: Go-Releaser
 
 on:
@@ -17,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux, windows]  # 移除 darwin
+        goos: [linux, windows]
         goarch: [amd64, arm64, arm]
         include:
           - goos: linux
@@ -36,25 +33,17 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set APP_VERSION env
-      run: echo APP_VERSION=$(basename ${GITHUB_REF}) >> ${GITHUB_ENV}
-
-    - name: Set ldflags as environment variable
-      run: |
-        if [ ${{ matrix.goos }} == 'linux' ]&&[ ${{ matrix.goarch }} == 'amd64' ]; then
-          LD_FLAGS="-X main.Version=${{ env.APP_VERSION }} -linkmode 'external' -extldflags '-static'"
-        else
-          LD_FLAGS="-X main.Version=${{ env.APP_VERSION }}"
-        fi
-        echo "LD_FLAGS=$LD_FLAGS" >> ${GITHUB_ENV}
-
-    - uses: wangyoucao577/go-release-action@v1
+    - name: Set up Go
+      uses: actions/setup-go@v4
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        goos: ${{ matrix.goos }}
-        goarch: ${{ matrix.goarch }}
-        gomips: ${{ matrix.gomips }}
-        project_path: "."
-        binary_name: "CloudflareWarpSpeedTest"
-        goversion: "1.22"
-        ldflags: "${{ env.LD_FLAGS }}"
+        go-version: '1.22'
+
+    - name: Build
+      run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} GOMIPS=${{ matrix.gomips }} go build -ldflags "-X main.Version=${{ github.ref_name }}" -o CloudflareWarpSpeedTest-${{ matrix.goos }}-${{ matrix.goarch }}
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: CloudflareWarpSpeedTest-${{ matrix.goos }}-${{ matrix.goarch }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,11 @@ jobs:
           - goos: linux
             goarch: arm
             goarm: 7
+        exclude:  # 排除不支持的平台
+          - goos: darwin
+            goarch: arm
     steps:
-      - uses: actions/checkout@v4  # 使用 v4 版本
+      - uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -30,17 +33,17 @@ jobs:
       - name: Build
         run: |
           mkdir -p build-${{ matrix.goos }}-${{ matrix.goarch }}
-          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} go build -v -o build-${{ matrix.goos }}-${{ matrix.goarch }}/CloudflareWarpSpeedTest ./...
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} go build -v -o build-${{ matrix.goos }}-${{ matrix.goarch }} ./...
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4  # 使用 v4 版本
+        uses: actions/upload-artifact@v4
         with:
           name: CloudflareWarpSpeedTest-${{ matrix.goos }}-${{ matrix.goarch }}
           path: build-${{ matrix.goos }}-${{ matrix.goarch }}
 
       - name: Release
         uses: softprops/action-gh-release@v1
-        if: ${{ matrix.goos == 'linux' && matrix.goarch == 'amd64' }}  # 只在 linux/amd64 上发布 Release
+        if: ${{ matrix.goos == 'linux' && matrix.goarch == 'amd64' }}
         with:
           files: |
             build-linux-amd64/CloudflareWarpSpeedTest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,16 +21,6 @@ jobs:
           - goos: linux
             goarch: arm
             goarm: 7
-          - goos: linux
-            goarch: mips
-            gomips: softfloat
-          - goos: linux
-            goarch: mipsle
-            gomips: softfloat
-          - goos: linux
-            goarch: mips64
-          - goos: linux
-            goarch: mips64le
     steps:
     - uses: actions/checkout@v3
 
@@ -52,7 +42,7 @@ jobs:
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
         goarm: ${{ matrix.goarm }}
-        gomips: ${{ matrix.gomips }}
+        # gomips: ${{ matrix.gomips }}  # 不需要 MIPS 相关参数
         project_path: "."
         binary_name: "CloudflareWarpSpeedTest"
         goversion: "1.22"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         fi
         echo "LD_FLAGS=$LD_FLAGS" >> ${GITHUB_ENV}
 
-    - uses: wangyoucao577/go-release-action@v1
+    - uses: wangyoucao577/go-release-action@v1.51
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           - goos: linux
             goarch: arm
             goarm: 7
-        exclude:  # 排除不支持的平台
+        exclude:
           - goos: darwin
             goarch: arm
     steps:
@@ -32,6 +32,7 @@ jobs:
 
       - name: Build
         run: |
+          cd ${{ github.workspace }}  # 切换到项目根目录
           mkdir -p build-${{ matrix.goos }}-${{ matrix.goarch }}
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} go build -v -o build-${{ matrix.goos }}-${{ matrix.goarch }} ./...
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release for armv7l
+name: Release for multiple platforms
 
 on:
   release:
@@ -9,9 +9,28 @@ permissions:
   packages: write
 
 jobs:
-  release:
-    name: Release Go Binary for armv7l
+  releases-matrix:
+    name: Release Go Binary
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, linux/armv7, windows/386, windows/amd64
+        goos: [linux, windows]
+        goarch: [386, amd64, arm64]
+        include:
+          - goos: linux
+            goarch: arm
+            goarm: 7
+          - goos: linux
+            goarch: mips
+            gomips: softfloat
+          - goos: linux
+            goarch: mipsle
+            gomips: softfloat
+          - goos: linux
+            goarch: mips64
+          - goos: linux
+            goarch: mips64le
     steps:
     - uses: actions/checkout@v3
 
@@ -19,14 +38,21 @@ jobs:
       run: echo APP_VERSION=$(basename ${GITHUB_REF}) >> ${GITHUB_ENV}
 
     - name: Set ldflags as environment variable
-      run: echo "LD_FLAGS=-X main.Version=${{ env.APP_VERSION }}" >> ${GITHUB_ENV}
+      run: |
+        if [ ${{ matrix.goos }} == 'linux' ]&&[ ${{ matrix.goarch }} == 'amd64' ]; then
+          LD_FLAGS="-X main.Version=${{ env.APP_VERSION }} -linkmode 'external' -extldflags '-static'"
+        else
+          LD_FLAGS="-X main.Version=${{ env.APP_VERSION }}"
+        fi
+        echo "LD_FLAGS=$LD_FLAGS" >> ${GITHUB_ENV}
 
     - uses: wangyoucao577/go-release-action@v1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        goos: linux
-        goarch: arm
-        goarm: 7
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        goarm: ${{ matrix.goarm }}
+        gomips: ${{ matrix.gomips }}
         project_path: "."
         binary_name: "CloudflareWarpSpeedTest"
         goversion: "1.22"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build
         run: |
-          cd ${{ github.workspace }}  # 切换到项目根目录
+          cd ${{ github.workspace }} 
           mkdir -p build-${{ matrix.goos }}-${{ matrix.goarch }}
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} go build -v -o build-${{ matrix.goos }}-${{ matrix.goarch }} ./...
 
@@ -47,12 +47,12 @@ jobs:
         if: ${{ matrix.goos == 'linux' && matrix.goarch == 'amd64' }}
         with:
           files: |
-            build-linux-amd64/CloudflareWarpSpeedTest
-            build-linux-arm64/CloudflareWarpSpeedTest
-            build-linux-arm/CloudflareWarpSpeedTest
-            build-windows-amd64/CloudflareWarpSpeedTest
-            build-windows-arm64/CloudflareWarpSpeedTest
-            build-darwin-amd64/CloudflareWarpSpeedTest
-            build-darwin-arm64/CloudflareWarpSpeedTest
+            ${{ github.workspace }}/build-linux-amd64/CloudflareWarpSpeedTest
+            ${{ github.workspace }}/build-linux-arm64/CloudflareWarpSpeedTest
+            ${{ github.workspace }}/build-linux-arm/CloudflareWarpSpeedTest
+            ${{ github.workspace }}/build-windows-amd64/CloudflareWarpSpeedTest
+            ${{ github.workspace }}/build-windows-arm64/CloudflareWarpSpeedTest
+            ${{ github.workspace }}/build-darwin-amd64/CloudflareWarpSpeedTest
+            ${{ github.workspace }}/build-darwin-arm64/CloudflareWarpSpeedTest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# This workflow will build a golang project
+
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go-Releaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,60 +1,54 @@
-# This workflow will build a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
-name: Go-Releaser
+name: Go Release
 
 on:
   release:
     types: [created]
 
 permissions:
-    contents: write
-    packages: write
+  contents: write
+  packages: write
 
 jobs:
-  releases-matrix:
-    name: Release Go Binary
+  release:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux, windows]  # 移除 darwin
+        goos: [linux, windows, darwin]
         goarch: [amd64, arm64, arm]
         include:
-          - goos: linux
-            goarch: mips
-            gomips: softfloat
-          - goos: linux
-            goarch: mipsle
-            gomips: softfloat
-          - goos: linux
-            goarch: mips64
-          - goos: linux
-            goarch: mips64le
           - goos: linux
             goarch: arm
             goarm: 7
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v4  # 使用 v4 版本
 
-    - name: Set APP_VERSION env
-      run: echo APP_VERSION=$(basename ${GITHUB_REF}) >> ${GITHUB_ENV}
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
 
-    - name: Set ldflags as environment variable
-      run: |
-        if [ ${{ matrix.goos }} == 'linux' ]&&[ ${{ matrix.goarch }} == 'amd64' ]; then
-          LD_FLAGS="-X main.Version=${{ env.APP_VERSION }} -linkmode 'external' -extldflags '-static'"
-        else
-          LD_FLAGS="-X main.Version=${{ env.APP_VERSION }}"
-        fi
-        echo "LD_FLAGS=$LD_FLAGS" >> ${GITHUB_ENV}
+      - name: Build
+        run: |
+          mkdir -p build-${{ matrix.goos }}-${{ matrix.goarch }}
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} go build -v -o build-${{ matrix.goos }}-${{ matrix.goarch }}/CloudflareWarpSpeedTest ./...
 
-    - uses: wangyoucao577/go-release-action@v1
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        goos: ${{ matrix.goos }}
-        goarch: ${{ matrix.goarch }}
-        gomips: ${{ matrix.gomips }}
-        project_path: "."
-        binary_name: "CloudflareWarpSpeedTest"
-        goversion: "1.22"
-        ldflags: "${{ env.LD_FLAGS }}"
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4  # 使用 v4 版本
+        with:
+          name: CloudflareWarpSpeedTest-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: build-${{ matrix.goos }}-${{ matrix.goarch }}
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: ${{ matrix.goos == 'linux' && matrix.goarch == 'amd64' }}  # 只在 linux/amd64 上发布 Release
+        with:
+          files: |
+            build-linux-amd64/CloudflareWarpSpeedTest
+            build-linux-arm64/CloudflareWarpSpeedTest
+            build-linux-arm/CloudflareWarpSpeedTest
+            build-windows-amd64/CloudflareWarpSpeedTest
+            build-windows-arm64/CloudflareWarpSpeedTest
+            build-darwin-amd64/CloudflareWarpSpeedTest
+            build-darwin-arm64/CloudflareWarpSpeedTest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,3 @@
-# This workflow will build a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
 name: Go-Releaser
 
 on:
@@ -8,8 +5,8 @@ on:
     types: [created]
 
 permissions:
-    contents: write
-    packages: write
+  contents: write
+  packages: write
 
 jobs:
   releases-matrix:
@@ -19,8 +16,10 @@ jobs:
       matrix:
         # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, darwin/amd64, darwin/arm64
         goos: [linux, windows, darwin]
-        goarch: [amd64, arm64]
+        goarch: [amd64, arm64, 386, armv7]
         include:
+          - goos: linux
+            goarch: armv7
           - goos: linux
             goarch: mips
             gomips: softfloat
@@ -31,6 +30,7 @@ jobs:
             goarch: mips64
           - goos: linux
             goarch: mips64le
+
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,36 +1,17 @@
-
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
-name: Go-Releaser
+name: Release for armv7l
 
 on:
   release:
     types: [created]
 
 permissions:
-    contents: write
-    packages: write
+  contents: write
+  packages: write
 
 jobs:
-  releases-matrix:
-    name: Release Go Binary
+  release:
+    name: Release Go Binary for armv7l
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, darwin/amd64, darwin/arm64
-        goos: [linux, windows, darwin]
-        goarch: [amd64, arm64]
-        include:
-          - goos: linux
-            goarch: mips
-            gomips: softfloat
-          - goos: linux
-            goarch: mipsle
-            gomips: softfloat
-          - goos: linux
-            goarch: mips64
-          - goos: linux
-            goarch: mips64le
     steps:
     - uses: actions/checkout@v3
 
@@ -38,20 +19,14 @@ jobs:
       run: echo APP_VERSION=$(basename ${GITHUB_REF}) >> ${GITHUB_ENV}
 
     - name: Set ldflags as environment variable
-      run: |
-        if [ ${{ matrix.goos }} == 'linux' ]&&[ ${{ matrix.goarch }} == 'amd64' ]; then
-          LD_FLAGS="-X main.Version=${{ env.APP_VERSION }} -linkmode 'external' -extldflags '-static'"
-        else
-          LD_FLAGS="-X main.Version=${{ env.APP_VERSION }}"
-        fi
-        echo "LD_FLAGS=$LD_FLAGS" >> ${GITHUB_ENV}
+      run: echo "LD_FLAGS=-X main.Version=${{ env.APP_VERSION }}" >> ${GITHUB_ENV}
 
     - uses: wangyoucao577/go-release-action@v1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        goos: ${{ matrix.goos }}
-        goarch: ${{ matrix.goarch }}
-        gomips: ${{ matrix.gomips }}
+        goos: linux
+        goarch: arm
+        goarm: 7
         project_path: "."
         binary_name: "CloudflareWarpSpeedTest"
         goversion: "1.22"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@ on:
     types: [created]
 
 permissions:
-    contents: write
-    packages: write
+  contents: write
+  packages: write
 
 jobs:
   releases-matrix:
@@ -14,9 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux, windows]
-        goarch: [amd64, arm64, arm]
+        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, darwin/amd64, darwin/arm64
+        goos: [linux, windows, darwin]
+        goarch: [amd64, arm64, 386, armv7]
         include:
+          - goos: linux
+            goarch: armv7
           - goos: linux
             goarch: mips
             gomips: softfloat
@@ -27,23 +30,29 @@ jobs:
             goarch: mips64
           - goos: linux
             goarch: mips64le
-          - goos: linux
-            goarch: arm
-            goarm: 7
+
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.22'
+    - name: Set APP_VERSION env
+      run: echo APP_VERSION=$(basename ${GITHUB_REF}) >> ${GITHUB_ENV}
 
-    - name: Build
-      run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} GOMIPS=${{ matrix.gomips }} go build -ldflags "-X main.Version=${{ github.ref_name }}" -o CloudflareWarpSpeedTest-${{ matrix.goos }}-${{ matrix.goarch }}
+    - name: Set ldflags as environment variable
+      run: |
+        if [ ${{ matrix.goos }} == 'linux' ]&&[ ${{ matrix.goarch }} == 'amd64' ]; then
+          LD_FLAGS="-X main.Version=${{ env.APP_VERSION }} -linkmode 'external' -extldflags '-static'"
+        else
+          LD_FLAGS="-X main.Version=${{ env.APP_VERSION }}"
+        fi
+        echo "LD_FLAGS=$LD_FLAGS" >> ${GITHUB_ENV}
 
-    - name: Release
-      uses: softprops/action-gh-release@v1
+    - uses: wangyoucao577/go-release-action@v1
       with:
-        files: CloudflareWarpSpeedTest-${{ matrix.goos }}-${{ matrix.goarch }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        gomips: ${{ matrix.gomips }}
+        project_path: "."
+        binary_name: "CloudflareWarpSpeedTest"
+        goversion: "1.22"
+        ldflags: "${{ env.LD_FLAGS }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@ on:
     types: [created]
 
 permissions:
-  contents: write
-  packages: write
+    contents: write
+    packages: write
 
 jobs:
   releases-matrix:
@@ -14,12 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, darwin/amd64, darwin/arm64
-        goos: [linux, windows, darwin]
-        goarch: [amd64, arm64, 386, armv7]
+        goos: [linux, windows]
+        goarch: [amd64, arm64, arm]
         include:
-          - goos: linux
-            goarch: armv7
           - goos: linux
             goarch: mips
             gomips: softfloat
@@ -30,29 +27,23 @@ jobs:
             goarch: mips64
           - goos: linux
             goarch: mips64le
-
+          - goos: linux
+            goarch: arm
+            goarm: 7
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set APP_VERSION env
-      run: echo APP_VERSION=$(basename ${GITHUB_REF}) >> ${GITHUB_ENV}
-
-    - name: Set ldflags as environment variable
-      run: |
-        if [ ${{ matrix.goos }} == 'linux' ]&&[ ${{ matrix.goarch }} == 'amd64' ]; then
-          LD_FLAGS="-X main.Version=${{ env.APP_VERSION }} -linkmode 'external' -extldflags '-static'"
-        else
-          LD_FLAGS="-X main.Version=${{ env.APP_VERSION }}"
-        fi
-        echo "LD_FLAGS=$LD_FLAGS" >> ${GITHUB_ENV}
-
-    - uses: wangyoucao577/go-release-action@v1
+    - name: Set up Go
+      uses: actions/setup-go@v4
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        goos: ${{ matrix.goos }}
-        goarch: ${{ matrix.goarch }}
-        gomips: ${{ matrix.gomips }}
-        project_path: "."
-        binary_name: "CloudflareWarpSpeedTest"
-        goversion: "1.22"
-        ldflags: "${{ env.LD_FLAGS }}"
+        go-version: '1.22'
+
+    - name: Build
+      run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} GOMIPS=${{ matrix.gomips }} go build -ldflags "-X main.Version=${{ github.ref_name }}" -o CloudflareWarpSpeedTest-${{ matrix.goos }}-${{ matrix.goarch }}
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: CloudflareWarpSpeedTest-${{ matrix.goos }}-${{ matrix.goarch }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,6 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
 name: Go-Releaser
 
 on:
@@ -5,8 +8,8 @@ on:
     types: [created]
 
 permissions:
-  contents: write
-  packages: write
+    contents: write
+    packages: write
 
 jobs:
   releases-matrix:
@@ -14,12 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, darwin/amd64, darwin/arm64
         goos: [linux, windows, darwin]
-        goarch: [amd64, arm64, 386, armv7]
+        goarch: [amd64, arm64, arm]  # 添加 arm
         include:
-          - goos: linux
-            goarch: armv7
           - goos: linux
             goarch: mips
             gomips: softfloat
@@ -30,7 +30,9 @@ jobs:
             goarch: mips64
           - goos: linux
             goarch: mips64le
-
+          - goos: linux  # 添加 armv7 配置
+            goarch: arm
+            goarm: 7
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, linux/armv7, windows/386, windows/amd64
-        goos: [linux, windows]
+        goos: [linux, windows, darwin]
         goarch: [386, amd64, arm64]
         include:
           - goos: linux
             goarch: arm
             goarm: 7
+          - goos: linux
+            goarch: mips
+            gomips: softfloat
+          - goos: linux
+            goarch: mipsle
+            gomips: softfloat
+          - goos: linux
+            goarch: mips64
+          - goos: linux
+            goarch: mips64le
+        exclude:
+          - goos: darwin
+            goarch: arm 
     steps:
     - uses: actions/checkout@v3
 
@@ -42,7 +54,7 @@ jobs:
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
         goarm: ${{ matrix.goarm }}
-        # gomips: ${{ matrix.gomips }}  # 不需要 MIPS 相关参数
+        gomips: ${{ matrix.gomips }}
         project_path: "."
         binary_name: "CloudflareWarpSpeedTest"
         goversion: "1.22"


### PR DESCRIPTION
This pull request improves the release workflow by adding support for the Linux ARMv7 (arm/7) architecture and fixing a build issue related to MIPS architectures.

**Changes:**

- **Added support for Linux ARMv7 (arm/7):** This allows the project to be built and released for devices using the ARMv7 architecture, expanding its compatibility.
- **Excluded unsupported macOS architectures:** The `darwin/arm` and `darwin/386` architectures have been excluded from the build matrix, as they are not supported by macOS.
- **Fixed MIPS build issue:** The original `wangyoucao577/go-release-action@v1` action had a bug in its `release.sh` script that caused a "mips: unbound variable" error. This issue has been resolved by using a forked and modified version of the action: `pdahd/go-release-action@v0.1-test-assets`. The fix involves changing the string comparison method in the script to correctly handle MIPS architectures.

**Benefits:**

- **Wider platform support:** The project can now be used on a wider range of devices, including those using the ARMv7 architecture.
- **Improved build reliability:** The fixed MIPS build issue ensures that the release workflow runs smoothly and produces binaries for all supported platforms.

**Testing:**

The updated release workflow has been tested successfully, and all supported platforms and architectures have been built and released without errors.

**Recommendation:**

I recommend releasing a new version of the project that includes these changes, potentially as `v1.5.4` or `v1.6.0`.
![Image Description](https://cdn.discordapp.com/attachments/1165634294736232510/1283586774362488862/IMG_20240912_081539.jpg?ex=66e388d6&is=66e23756&hm=9ac6d0003e5a2bb704254e6af673cdcc3bffb52abdaf5c6f83a78450a7b25e96&)